### PR TITLE
DEVPLAT-7373 Update action to use node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ outputs:
   found-user:
     description: Boolean indicating if a matching Slack username was found.
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
We use this action in the monolith and in order to remove warnings in ci we need to update it to use node24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the GitHub Action runtime from Node 20 to Node 24 with no logic changes. Main risk is runtime compatibility if dependencies or `index.js` rely on removed Node APIs.
> 
> **Overview**
> Updates the GitHub Action runtime in `action.yml` to run on **Node 24** instead of **Node 20**, primarily to eliminate CI deprecation warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74b39f55855f7ccb59a0901b495e589c9b0f5031. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->